### PR TITLE
twofactor_code parameter conditional requirement

### DIFF
--- a/ITrade/SendOffer.md
+++ b/ITrade/SendOffer.md
@@ -12,7 +12,7 @@ API key required.
 
 Parameter | Type | Required   | Description
 --------- | -----| :--------: | -----------
-twofactor_code | string | + | 2-factor authentication code
+twofactor_code | string | | 2-factor authentication code. Required if including your own items.
 uid | int | + | User ID of user you want to send your trade offer to
 token | string | + | Trade token of user you want to send your trade offer to
 items | string | + | A comma-separated list of item ids you wish to include in trade offer. There should be both yours and recipients items. 100 maximum per each side.


### PR DESCRIPTION
twofactor_code is not required when you are not sending any items to other party