### PR TITLE
Few mistakes in api documentation

### DIFF
--- a/IItem.md
+++ b/IItem.md
@@ -24,7 +24,7 @@ id | int | Item ID
 internal_app_id | int | Internal App ID (see [ITrade/GetApps](/ITrade/GetApps.md))
 sku | int | Item definition (meta-data) SKU #
 wear | float | Wear float value, only applicable for certain apps
-tradeable | bool | Is item tradeable
+tradable | bool | Is item tradable? Items may be temporarily untradable during certain operations, e.g. transfers.
 trade_hold_expires | int / null | Trade hold expiration date. `null` if no trade hold
 name | string | Market name e.g. `AK-47 Anubis (Minimal Wear)`
 category | string | Category name e.g. `Covert Rifle`

--- a/IItem.md
+++ b/IItem.md
@@ -24,6 +24,7 @@ id | int | Item ID
 internal_app_id | int | Internal App ID (see [ITrade/GetApps](/ITrade/GetApps.md))
 sku | int | Item definition (meta-data) SKU #
 wear | float | Wear float value, only applicable for certain apps
+tradeable | bool | Is item tradeable
 trade_hold_expires | int / null | Trade hold expiration date. `null` if no trade hold
 name | string | Market name e.g. `AK-47 Anubis (Minimal Wear)`
 category | string | Category name e.g. `Covert Rifle`

--- a/ITrade/AcceptOffer.md
+++ b/ITrade/AcceptOffer.md
@@ -15,7 +15,7 @@ API key required.
 
 Parameter | Type | Required   | Description
 --------- | -----| :--------: | -----------
-twofactor_code | string | + | 2-factor authentication code
+twofactor_code | int | + | 2-factor authentication code
 offer_id | int | + | Trade offer Id you want to accept
 
     

--- a/ITrade/AcceptOffer.md
+++ b/ITrade/AcceptOffer.md
@@ -15,7 +15,7 @@ API key required.
 
 Parameter | Type | Required   | Description
 --------- | -----| :--------: | -----------
-twofactor_code | int | + | 2-factor authentication code
+twofactor_code | string | + | 2-factor authentication code
 offer_id | int | + | Trade offer Id you want to accept
 
     

--- a/ITrade/GetUserInventoryFromSteamId.md
+++ b/ITrade/GetUserInventoryFromSteamId.md
@@ -14,7 +14,7 @@ API key required.
 
 Parameter | Type | Required   | Description
 --------- | -----| :--------: | -----------
-steam_id | int |  + | Steam ID of user whose inventory you want to see 
+steam_id | string |  + | Steam ID of user whose inventory you want to see 
 app_id | int | + | Internal App ID (see [ITrade/GetApps](/ITrade/GetApps.md))
 page | int |  | Page number in response (starting with 1, default to 1) 
 per_page | int |  | Number of items per_page in response (no more than 500)

--- a/ITrade/SendOfferToSteamId.md
+++ b/ITrade/SendOfferToSteamId.md
@@ -15,7 +15,7 @@ API key required.
 
 Parameter | Type | Required   | Description
 --------- | -----| :--------: | -----------
-twofactor_code | string | + | 2FA Auth Code
+twofactor_code | int | + | 2FA Auth Code
 steam_id | string | + | Steam ID of user you want to send your trade offer to
 items_to_send | csv-int | | A comma-separated list of (int) Item IDs you wish to send to recipient. Maximum `100` items.
 items_to_receive | csv-int | | A comma-separated list of (int) Item IDs you wish to receive from the recipient. Maximum `100` items.

--- a/ITrade/SendOfferToSteamId.md
+++ b/ITrade/SendOfferToSteamId.md
@@ -15,7 +15,7 @@ API key required.
 
 Parameter | Type | Required   | Description
 --------- | -----| :--------: | -----------
-twofactor_code | int | + | 2FA Auth Code
+twofactor_code | string | + | 2FA Auth Code
 steam_id | string | + | Steam ID of user you want to send your trade offer to
 items_to_send | csv-int | | A comma-separated list of (int) Item IDs you wish to send to recipient. Maximum `100` items.
 items_to_receive | csv-int | | A comma-separated list of (int) Item IDs you wish to receive from the recipient. Maximum `100` items.

--- a/ITrade/SendOfferToSteamId.md
+++ b/ITrade/SendOfferToSteamId.md
@@ -16,7 +16,7 @@ API key required.
 Parameter | Type | Required   | Description
 --------- | -----| :--------: | -----------
 twofactor_code | int | + | 2FA Auth Code
-steam_id | int | + | Steam ID of user you want to send your trade offer to
+steam_id | string | + | Steam ID of user you want to send your trade offer to
 items_to_send | csv-int | | A comma-separated list of (int) Item IDs you wish to send to recipient. Maximum `100` items.
 items_to_receive | csv-int | | A comma-separated list of (int) Item IDs you wish to receive from the recipient. Maximum `100` items.
 expiration_time | int | | Custom expiration time for an offer in `seconds`. Minimum 120 seconds (2 minutes). Defaults to 14 days.


### PR DESCRIPTION
I'm currently building SDK in Java for yours api, and found some mistakes.

I suggest to change steamId parameter to string, because it's exceeds the range of Integer.
Also, found some missing property in Standard Trade Object.